### PR TITLE
flag on the testclient to catch unhandle server exceptions

### DIFF
--- a/async_asgi_testclient/testing.py
+++ b/async_asgi_testclient/testing.py
@@ -49,7 +49,7 @@ class TestClient:
     the app for testing purposes.
     """
 
-    def __init__(self, application, raise_server_exceptions=True):
+    def __init__(self, application, raise_server_exceptions=False):
         self.application = guarantee_single_callable(application)
         self.cookie_jar = SimpleCookie()
         self.lifespan_input_queue = asyncio.Queue()

--- a/async_asgi_testclient/testing.py
+++ b/async_asgi_testclient/testing.py
@@ -186,10 +186,12 @@ class TestClient:
             except Exception as exc:
                 if not self.raise_server_exceptions:
                     response.status_code = 500
-                    response.raw.write(bytes(
-                        "".join(traceback.format_tb(exc.__traceback__)),
-                        encoding='utf-8'
-                    ))
+                    response.raw.write(
+                        bytes(
+                            "".join(traceback.format_tb(exc.__traceback__)),
+                            encoding="utf-8",
+                        )
+                    )
                     await input_queue.put({"type": "http.disconnect"})
                     break
                 raise exc from None

--- a/async_asgi_testclient/tests/test_TestClient.py
+++ b/async_asgi_testclient/tests/test_TestClient.py
@@ -163,3 +163,16 @@ async def test_Starlette_TestClient(starlette_app):
         resp = await client.get("/cookie")
         assert resp.status_code == 200
         assert resp.json() == {"my-cookie": "1234"}
+
+
+@pytest.mark.asyncio
+async def test_exception_capture(starlette_app):
+    async def view_raiser(request):
+        assert 1 == 0
+
+    starlette_app.add_route("/raiser", view_raiser)
+
+    async with TestClient(
+        starlette_app, raise_server_exceptions=False) as client:
+        resp = await client.get("/raiser")
+        assert resp.status_code == 500

--- a/async_asgi_testclient/tests/test_TestClient.py
+++ b/async_asgi_testclient/tests/test_TestClient.py
@@ -172,7 +172,18 @@ async def test_exception_capture(starlette_app):
 
     starlette_app.add_route("/raiser", view_raiser)
 
-    async with TestClient(
-        starlette_app, raise_server_exceptions=False) as client:
+    async with TestClient(starlette_app) as client:
         resp = await client.get("/raiser")
         assert resp.status_code == 500
+
+
+@pytest.mark.asyncio
+async def test_exception_capture_release(starlette_app):
+    async def view_raiser(request):
+        assert 1 == 0
+
+    starlette_app.add_route("/raiser", view_raiser)
+
+    async with TestClient(starlette_app, raise_server_exceptions=True) as client:
+        with pytest.raises(AssertionError):
+            resp = await client.get("/raiser")

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,6 @@ setup(
     test_suite="tests",
     tests_require=test_requirements,
     url="https://github.com/vinissimus/async-asgi-testclient",
-    version="0.1",
+    version="0.1.1",
     zip_safe=False,
 )

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,6 @@ setup(
     test_suite="tests",
     tests_require=test_requirements,
     url="https://github.com/vinissimus/async-asgi-testclient",
-    version="0.1.1",
+    version="0.1.2",
     zip_safe=False,
 )


### PR DESCRIPTION
Following the same semantics on starlette, where, exceptions
are reraised to allow server process to catch them,
and show the proper stacktrace on logs, we need to provide
a flag on test client to catch them.

Anyway, seems like there is still not working the exception
propagation, I opened an issue on:

https://github.com/encode/starlette/issues/484

But right now, at least to be compact with starlette,
we need to provide this flag, like his own sync TestClient provides.

I know that with Quart nothing happens and this works as expected