### PR TITLE
Improved cookies support

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,3 @@
+[run]
+omit =
+    async_asgi_testclient/tests/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,4 @@ install:
   - pip install -r test-requirements.txt
 # command to run tests
 script:
-  - pytest async_asgi_testclient -v
+  - pytest --cov=async_asgi_testclient async_asgi_testclient -v

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,7 @@ install:
   - pip install -r test-requirements.txt
 # command to run tests
 script:
+  - black async_asgi_testclient
+  - flake8 async_asgi_testclient
+  - mypy async_asgi_testclient
   - pytest --cov=async_asgi_testclient async_asgi_testclient -v

--- a/async_asgi_testclient/testing.py
+++ b/async_asgi_testclient/testing.py
@@ -58,8 +58,8 @@ class TestClient:
         self.application = guarantee_single_callable(application)
         self.raise_server_exceptions = raise_server_exceptions
         self.cookie_jar = SimpleCookie() if use_cookies else None
-        self._lifespan_input_queue = asyncio.Queue()
-        self._lifespan_output_queue = asyncio.Queue()
+        self._lifespan_input_queue: asyncio.Queue[dict] = asyncio.Queue()
+        self._lifespan_output_queue: asyncio.Queue[dict] = asyncio.Queue()
 
     async def __aenter__(self):
         asyncio.ensure_future(

--- a/async_asgi_testclient/testing.py
+++ b/async_asgi_testclient/testing.py
@@ -127,6 +127,10 @@ class TestClient:
             scheme
                 The scheme to use in the request, default http.
 
+            cookies
+                Cookies to send in the request instead of cookies in
+                TestClient.cookie_jar
+
         Returns:
             The response from the app handling the request.
         """
@@ -157,7 +161,7 @@ class TestClient:
             request_data = urlencode(form).encode("utf-8")
             headers["Content-Type"] = "application/x-www-form-urlencoded"
 
-        if cookies is None:  # use cookie_jar from TestClient
+        if cookies is None:  # use TestClient.cookie_jar
             cookie_jar = self.cookie_jar
         else:
             cookie_jar = SimpleCookie(cookies)

--- a/async_asgi_testclient/tests/test_TestClient.py
+++ b/async_asgi_testclient/tests/test_TestClient.py
@@ -217,4 +217,4 @@ async def test_exception_capture_release(starlette_app):
 
     async with TestClient(starlette_app, raise_server_exceptions=True) as client:
         with pytest.raises(AssertionError):
-            resp = await client.get("/raiser")
+            await client.get("/raiser")

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,6 @@ setup(
     test_suite="tests",
     tests_require=test_requirements,
     url="https://github.com/vinissimus/async-asgi-testclient",
-    version="0.1.2",
+    version="0.1.3",
     zip_safe=False,
 )

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -3,3 +3,6 @@ starlette==0.12.0.b3
 python-multipart==0.0.5
 pytest==4.4.0
 pytest-asyncio==0.10.0
+black==19.3b0
+flake8==3.7.7
+mypy==0.701

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -3,6 +3,7 @@ starlette==0.12.0.b3
 python-multipart==0.0.5
 pytest==4.4.0
 pytest-asyncio==0.10.0
+pytest-cov==2.6.1
 black==19.3b0
 flake8==3.7.7
 mypy==0.701


### PR DESCRIPTION
- Add parameter `cookies` to methods `get()`, `post()`, `patch()`, ... to customize which cookies are sent to the server. If `cookies` is `None` sends the value of `TestClient.cookie_jar`
- Add parameter `use_cookies=True` to `TestClient`

Closes https://github.com/vinissimus/async-asgi-testclient/issues/4