### PR TITLE
Add client (remote peer) to scope

### DIFF
--- a/async_asgi_testclient/testing.py
+++ b/async_asgi_testclient/testing.py
@@ -63,6 +63,7 @@ class TestClient:
         use_cookies: bool = True,
         timeout: Optional[int] = None,
         headers: Optional[Union[dict, CIMultiDict]] = None,
+        scope: Optional[dict] = None,
     ):
         self.application = guarantee_single_callable(application)
         self.cookie_jar = SimpleCookie() if use_cookies else None
@@ -70,6 +71,7 @@ class TestClient:
         self._lifespan_output_queue: asyncio.Queue[dict] = asyncio.Queue()
         self.timeout = timeout
         self.headers = headers or {}
+        self._scope = scope or {}
 
     async def __aenter__(self):
         create_monitored_task(
@@ -213,8 +215,8 @@ class TestClient:
             "query_string": query_string_bytes,
             "root_path": "",
             "headers": flat_headers,
-            "client": ["127.0.0.1", 50000],
         }
+        scope.update(self._scope)
 
         create_monitored_task(
             self.application(scope, input_queue.get, output_queue.put),

--- a/async_asgi_testclient/testing.py
+++ b/async_asgi_testclient/testing.py
@@ -213,6 +213,7 @@ class TestClient:
             "query_string": query_string_bytes,
             "root_path": "",
             "headers": flat_headers,
+            "client": ["127.0.0.1", 50000],
         }
 
         create_monitored_task(


### PR DESCRIPTION
FastAPI provides the key client in the scope for accessing ip,port tuple of the request origin.
I lacked it for my tests, so added and think it might be usable for someone else.


P.S: Great repo, exactly what I lacked :) 