### PR TITLE
Remove default dict for self.cookies attr

### DIFF
--- a/async_asgi_testclient/tests/test_testing.py
+++ b/async_asgi_testclient/tests/test_testing.py
@@ -3,6 +3,7 @@ from json import dumps
 from sys import version_info as PY_VER  # noqa
 
 import asyncio
+from http.cookies import SimpleCookie
 import io
 import pytest
 
@@ -393,6 +394,17 @@ async def test_ws_endpoint(starlette_app):
 async def test_ws_endpoint_cookies(starlette_app):
     async with TestClient(starlette_app, timeout=0.1) as client:
         async with client.websocket_connect("/ws", cookies={"session": "abc"}) as ws:
+            await ws.send_text("cookies")
+            msg = await ws.receive_text()
+            assert msg == '{"session": "abc"}'
+
+
+@pytest.mark.asyncio
+async def test_ws_connect_inherits_test_client_cookies(starlette_app):
+    client = TestClient(starlette_app, use_cookies=True, timeout=0.1)
+    client.cookie_jar = SimpleCookie({"session": "abc"})
+    async with client:
+        async with client.websocket_connect("/ws") as ws:
             await ws.send_text("cookies")
             msg = await ws.receive_text()
             assert msg == '{"session": "abc"}'

--- a/async_asgi_testclient/tests/test_testing.py
+++ b/async_asgi_testclient/tests/test_testing.py
@@ -1,9 +1,9 @@
 from async_asgi_testclient import TestClient
+from http.cookies import SimpleCookie
 from json import dumps
 from sys import version_info as PY_VER  # noqa
 
 import asyncio
-from http.cookies import SimpleCookie
 import io
 import pytest
 

--- a/async_asgi_testclient/websocket.py
+++ b/async_asgi_testclient/websocket.py
@@ -22,7 +22,7 @@ class WebSocketSession:
         self.testclient = testclient
         self.path = path
         self.headers = headers or {}
-        self.cookies = cookies or {}
+        self.cookies = cookies
         self.input_queue: asyncio.Queue[dict] = asyncio.Queue()
         self.output_queue: asyncio.Queue[dict] = asyncio.Queue()
 


### PR DESCRIPTION
In `WebSocketSession.connect()` method, check if `self.cookies` is None to use TestClient.cookie_jar.
But `self.cookies` is never be None because the line `self.cookies = cookies or {}` exists in its constructor.