### PR TITLE
Add support for Python 3.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python:
   - "3.6"
   - "3.7"
   - "3.8"
+  - "3.9"
 # command to install dependencies
 install:
   - pip install codecov

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-multidict~=4.0
+multidict>=4.0,<=6.0
 requests~=2.21

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-multidict>=4.0,<=6.0
+multidict>=4.0,<6.0
 requests~=2.21

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ setup(
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
     ],
     description="Async client for testing ASGI web applications",
     install_requires=requirements,


### PR DESCRIPTION
### CHANGES
* Add travis builds for Python 3.9
* Allow usage of the latest `multidict` version