### PR TITLE
fix Cookie header rendering in requests

### DIFF
--- a/async_asgi_testclient/testing.py
+++ b/async_asgi_testclient/testing.py
@@ -219,8 +219,12 @@ class TestClient:
         else:
             cookie_jar = SimpleCookie(cookies)
 
-        if cookie_jar and cookie_jar.output(header=""):
-            headers.add("Cookie", cookie_jar.output(header=""))
+        if cookie_jar:
+            cookie_data = []
+            for cookie_name, cookie in cookie_jar.items():
+                cookie_data.append(f'{cookie_name}={cookie.value}')
+            if cookie_data:
+                headers.add("Cookie", '; '.join(cookie_data))
 
         scope = {
             "type": "http",

--- a/async_asgi_testclient/tests/test_testing.py
+++ b/async_asgi_testclient/tests/test_testing.py
@@ -60,6 +60,10 @@ def quart_app():
         cookies = request.cookies
         return jsonify(cookies)
 
+    @app.route("/cookies-raw")
+    async def get_cookie_raw():
+        return Response(request.headers['Cookie'])
+
     @app.route("/stuck")
     async def stuck():
         await asyncio.sleep(60)
@@ -165,6 +169,10 @@ def starlette_app():
         cookies = request.cookies
         return JSONResponse(cookies)
 
+    @app.route("/cookies-raw")
+    async def get_cookie_raw(request):
+        return Response(request.headers['Cookie'])
+
     @app.route("/stuck")
     async def stuck(request):
         await asyncio.sleep(60)
@@ -211,6 +219,10 @@ async def test_TestClient_Quart(quart_app):
         resp = await client.get("/cookies")
         assert resp.status_code == 200
         assert resp.json() == {"my-cookie": "1234", "my-cookie-2": "5678"}
+
+        resp = await client.get("/cookies-raw")
+        assert resp.status_code == 200
+        assert resp.text == "my-cookie=1234; my-cookie-2=5678"
 
         resp = await client.post("/clear_cookie")
         assert resp.cookies.get_dict() == {"my-cookie": "", "my-cookie-2": ""}
@@ -285,6 +297,10 @@ async def test_TestClient_Starlette(starlette_app):
         assert resp.status_code == 200
         assert resp.json() == {"my-cookie": "1234", "my-cookie-2": "5678"}
 
+        resp = await client.get("/cookies-raw")
+        assert resp.status_code == 200
+        assert resp.text == "my-cookie=1234; my-cookie-2=5678"
+
         resp = await client.post("/clear_cookie")
         assert resp.cookies.get_dict() == {"my-cookie": "", "my-cookie-2": ""}
         assert resp.status_code == 200
@@ -328,6 +344,10 @@ async def test_set_cookie_in_request(quart_app):
         resp = await client.get("/cookies")
         assert resp.status_code == 200
         assert resp.json() == {"my-cookie": "1234", "my-cookie-2": "5678"}
+
+        resp = await client.get("/cookies-raw")
+        assert resp.status_code == 200
+        assert resp.text == "my-cookie=1234; my-cookie-2=5678"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
I made a fix which renders cookies correctly in request header.
In the previous code `cookie_jar.output(headers="")` was rendering cookies as for `Set-Cookie` response header, which means that additional flags like `Expires`, `Max-Age`, `SameSite` etc was added.

## Why it was working?
Because both tested framework - Quart and Starlette, in versions specified in requirements, uses same library and SimpleCookie to parse this header. So even with Set-Cookie syntax in the header, all tests were passing as SimpleCookie.load method supports both: `Cookie` and `Set-Cookie`

However, Starlette in the current version has custom cookie parsing mechanism and updating starlette cause tests failing.

## What has been changed

I've changed `Cookie` request header rendering, so only cookie name and value are rendered now. Also multiple cookies are correctly separated by `;` not `\r\n`. 
I've add a new `/cookie-raw` endpoint in both frameworks to make sure that `Cookie` header seen by the asgi app is correct. I was NOT updating Starlette.

This PR closes https://github.com/vinissimus/async-asgi-testclient/issues/41