### PR TITLE
#54 handle websocket rejections

### DIFF
--- a/async_asgi_testclient/tests/test_testing.py
+++ b/async_asgi_testclient/tests/test_testing.py
@@ -1,21 +1,20 @@
-import ast
-
-import starlette.status
-from quart import websocket
-
 from async_asgi_testclient import TestClient
 from http.cookies import SimpleCookie
 from json import dumps
+from starlette.responses import RedirectResponse
+from starlette.responses import StreamingResponse
 from sys import version_info as PY_VER  # noqa
 
+import ast
 import asyncio
 import io
 import pytest
+import starlette.status
 
 
 @pytest.fixture
 def quart_app():
-    from quart import Quart, jsonify, request, redirect, Response
+    from quart import Quart, jsonify, request, redirect, Response, websocket
 
     app = Quart(__name__)
 
@@ -97,7 +96,9 @@ def quart_app():
 
     @app.websocket("/ws-reject")
     async def websocket_reject():
-        await websocket.close(code=starlette.status.WS_1003_UNSUPPORTED_DATA, reason="some reason")
+        await websocket.close(
+            code=starlette.status.WS_1003_UNSUPPORTED_DATA, reason="some reason"
+        )
 
     yield app
 
@@ -210,6 +211,10 @@ def starlette_app():
     @app.route("/test_query")
     async def test_query(request):
         return Response(str(request.query_params))
+
+    @app.route("/redir")
+    async def redir(request):
+        return RedirectResponse(request.query_params["path"], status_code=302)
 
     yield app
 
@@ -377,6 +382,29 @@ async def test_set_cookie_in_request(quart_app):
 
 
 @pytest.mark.asyncio
+async def test_set_cookie_in_request_starlette(starlette_app):
+    async with TestClient(starlette_app) as client:
+        resp = await client.post("/set_cookies")
+        assert resp.status_code == 200
+        assert resp.cookies.get_dict() == {"my-cookie": "1234", "my-cookie-2": "5678"}
+
+        # Uses 'custom_cookie_jar' instead of 'client.cookie_jar'
+        custom_cookie_jar = {"my-cookie": "6666"}
+        resp = await client.get("/cookies", cookies=custom_cookie_jar)
+        assert resp.status_code == 200
+        assert resp.json() == custom_cookie_jar
+
+        # Uses 'client.cookie_jar' again
+        resp = await client.get("/cookies")
+        assert resp.status_code == 200
+        assert resp.json() == {"my-cookie": "1234", "my-cookie-2": "5678"}
+
+        resp = await client.get("/cookies-raw")
+        assert resp.status_code == 200
+        assert resp.text == "my-cookie=1234; my-cookie-2=5678"
+
+
+@pytest.mark.asyncio
 @pytest.mark.skipif("PY_VER < (3,7)")
 async def test_disable_cookies_in_client(quart_app):
     async with TestClient(quart_app, use_cookies=False) as client:
@@ -478,14 +506,14 @@ async def test_ws_connect_custom_scheme(starlette_app):
 async def test_ws_endpoint_with_immediate_rejection(starlette_app):
     async with TestClient(starlette_app, timeout=0.1) as client:
         try:
-            async with client.websocket_connect("/ws-reject") as ws:
+            async with client.websocket_connect("/ws-reject"):
                 pass
         except Exception as e:
             thrown_exception = e
 
         assert ast.literal_eval(str(thrown_exception)) == {
             "type": "websocket.close",
-            "code": starlette.status.WS_1003_UNSUPPORTED_DATA
+            "code": starlette.status.WS_1003_UNSUPPORTED_DATA,
         }
 
 
@@ -493,14 +521,14 @@ async def test_ws_endpoint_with_immediate_rejection(starlette_app):
 async def test_invalid_ws_endpoint(starlette_app):
     async with TestClient(starlette_app, timeout=0.1) as client:
         try:
-            async with client.websocket_connect("/invalid") as ws:
+            async with client.websocket_connect("/invalid"):
                 pass
         except Exception as e:
             thrown_exception = e
 
         assert ast.literal_eval(str(thrown_exception)) == {
             "type": "websocket.close",
-            "code": starlette.status.WS_1000_NORMAL_CLOSURE
+            "code": starlette.status.WS_1000_NORMAL_CLOSURE,
         }
 
 
@@ -537,6 +565,7 @@ async def test_quart_ws_connect_inherits_test_client_cookies(quart_app):
 
 
 @pytest.mark.asyncio
+@pytest.mark.skipif("PY_VER < (3,7)")
 async def test_quart_ws_connect_default_scheme(quart_app):
     async with TestClient(quart_app, timeout=0.1) as client:
         async with client.websocket_connect("/ws") as ws:
@@ -560,14 +589,14 @@ async def test_quart_ws_connect_custom_scheme(quart_app):
 async def test_quart_ws_endpoint_with_immediate_rejection(quart_app):
     async with TestClient(quart_app, timeout=0.1) as client:
         try:
-            async with client.websocket_connect("/ws-reject") as ws:
+            async with client.websocket_connect("/ws-reject"):
                 pass
         except Exception as e:
             thrown_exception = e
 
         assert ast.literal_eval(str(thrown_exception)) == {
             "type": "websocket.close",
-            "code": starlette.status.WS_1003_UNSUPPORTED_DATA
+            "code": starlette.status.WS_1003_UNSUPPORTED_DATA,
         }
 
 
@@ -576,14 +605,14 @@ async def test_quart_ws_endpoint_with_immediate_rejection(quart_app):
 async def test_quart_invalid_ws_endpoint(quart_app):
     async with TestClient(quart_app, timeout=0.1) as client:
         try:
-            async with client.websocket_connect("/invalid") as ws:
+            async with client.websocket_connect("/invalid"):
                 pass
         except Exception as e:
             thrown_exception = e
 
         assert ast.literal_eval(str(thrown_exception)) == {
             "type": "websocket.close",
-            "code": starlette.status.WS_1000_NORMAL_CLOSURE
+            "code": starlette.status.WS_1000_NORMAL_CLOSURE,
         }
 
 
@@ -664,7 +693,24 @@ async def test_response_stream(quart_app):
 
 
 @pytest.mark.asyncio
-async def test_response_stream_crashes(starlette_app):
+async def test_response_stream_starlette(starlette_app):
+    @starlette_app.route("/download_stream")
+    async def down_stream(_):
+        async def async_generator():
+            chunk = b"X" * 1024
+            for _ in range(3):
+                yield chunk
+
+        return StreamingResponse(async_generator())
+
+    async with TestClient(starlette_app) as client:
+        resp = await client.get("/download_stream", stream=False)
+        assert resp.status_code == 200
+        assert len(resp.content) == 3 * 1024
+
+
+@pytest.mark.asyncio
+async def test_response_stream_crashes_starlette(starlette_app):
     from starlette.responses import StreamingResponse
 
     @starlette_app.route("/download_stream_crashes")
@@ -699,5 +745,20 @@ async def test_follow_redirects(quart_app):
 @pytest.mark.skipif("PY_VER < (3,7)")
 async def test_no_follow_redirects(quart_app):
     async with TestClient(quart_app) as client:
+        resp = await client.get("/redir?path=/", allow_redirects=False)
+        assert resp.status_code == 302
+
+
+@pytest.mark.asyncio
+async def test_follow_redirects_starlette(starlette_app):
+    async with TestClient(starlette_app) as client:
+        resp = await client.get("/redir?path=/")
+        assert resp.status_code == 200
+        assert resp.text == "full response"
+
+
+@pytest.mark.asyncio
+async def test_no_follow_redirects_starlette(starlette_app):
+    async with TestClient(starlette_app) as client:
         resp = await client.get("/redir?path=/", allow_redirects=False)
         assert resp.status_code == 302

--- a/async_asgi_testclient/websocket.py
+++ b/async_asgi_testclient/websocket.py
@@ -87,10 +87,7 @@ class WebSocketSession:
         return json.loads(data)
 
     async def _receive(self):
-        try:
-            return await receive(self.output_queue)
-        except:
-            pass
+        return await receive(self.output_queue)
 
     def __aiter__(self):
         return self

--- a/async_asgi_testclient/websocket.py
+++ b/async_asgi_testclient/websocket.py
@@ -87,7 +87,10 @@ class WebSocketSession:
         return json.loads(data)
 
     async def _receive(self):
-        return await receive(self.output_queue)
+        try:
+            return await receive(self.output_queue)
+        except:
+            pass
 
     def __aiter__(self):
         return self
@@ -131,4 +134,5 @@ class WebSocketSession:
 
         await self._send({"type": "websocket.connect"})
         msg = await self._receive()
-        assert msg["type"] == "websocket.accept"
+        if msg["type"] != "websocket.accept":
+            raise Exception(msg)

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,4 @@
-quart==0.10.0; python_version >= '3.7'
+quart==0.17.0; python_version >= '3.7'
 starlette==0.12.13
 python-multipart==0.0.5
 pytest==6.2.5

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -4,7 +4,7 @@ python-multipart==0.0.5
 pytest==6.2.5
 pytest-asyncio==0.15.0
 pytest-cov==2.8.1
-black==19.10b0
+black==22.3.0
 flake8~=3.8.0
 mypy==0.761
 isort==4.3.21


### PR DESCRIPTION
Fixes #54 

- Test classes can now receive the early termination event as a raised Exception where the body of the exception is the closure message (incase validation is wanted to be done on the response)

- Also added tests for quartz WebSocket endpoints as they were missing